### PR TITLE
Add Playwright API Tests (Login & Create Order)

### DIFF
--- a/tests/utils/APiUtils.js
+++ b/tests/utils/APiUtils.js
@@ -1,0 +1,45 @@
+class APiUtils{
+
+
+    constructor(apiContext, LoginPayLoad){
+
+        this.apiContext = apiContext;    
+        this.LoginPayLoad = LoginPayLoad;   
+    }
+
+    async getToken(){
+
+    const loginResponse = await this.apiContext.post("https://rahulshettyacademy.com/api/ecom/auth/login", {data:this.LoginPayLoad})
+
+    //Login API
+    const loginResponseJSON = await loginResponse.json();
+    const token = loginResponseJSON.token;
+    console.log(token);
+    return token;
+    }
+
+    async createOrder(orderPayLoad){
+
+        let response = {};
+        response.token = await this.getToken();
+        
+            //Handle Order Creation API
+            const createOrderResponse = await this.apiContext.post("https://rahulshettyacademy.com/api/ecom/order/create-order", {
+                data: orderPayLoad,
+                headers: {
+                    "Authorization": response.token,
+                    "Content-Type": "application/json"
+                },
+        
+            })
+            const createOrderResponseJSON = await createOrderResponse.json();
+            console.log(createOrderResponseJSON);
+            const orderId = createOrderResponseJSON.orders[0];
+            response.orderId = orderId;
+
+            return response;
+    }
+
+}
+
+module.exports = {APiUtils};


### PR DESCRIPTION
Summary
This PR adds Playwright-based API tests that cover authentication and order creation.

Details
Implemented login API test to validate user authentication and retrieve token.
Implemented create order API test using the authenticated session.
Added assertions for response codes and payload structure.

Testing

Run tests with:
npx playwright test tests/api/login.spec.ts
npx playwright test tests/api/order.spec.ts


Expected Results
Login test returns a valid token.
Create order test returns 201 Created with correct order details.